### PR TITLE
[EDIFICE] #WB2-1301, rendre la purge plus fiable

### DIFF
--- a/deployment/sharebigfiles/migration/1.13.0/expiryIndex.js
+++ b/deployment/sharebigfiles/migration/1.13.0/expiryIndex.js
@@ -1,0 +1,1 @@
+db.bigfile.createIndex( { "expiryDate": 1, "outdated": 1 }, { sparse: true, background: true } )

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,9 +24,9 @@ groovyVersion=2.1.1
 gradleVersion=1.6
 
 # Provided
-vertxVersion=3.5.0
+vertxVersion=3.9.5
 toolsVersion=2.0.0-final
 junitVersion=4.10
 vertxCronTimer=2.0.0
 
-entCoreVersion=4.9-SNAPSHOT
+entCoreVersion=4.12-SNAPSHOT

--- a/src/main/java/fr/openent/sharebigfiles/ShareBigFiles.java
+++ b/src/main/java/fr/openent/sharebigfiles/ShareBigFiles.java
@@ -59,8 +59,8 @@ public class ShareBigFiles extends BaseServer {
 				new JsonArray(Arrays.asList(1, 5, 10, 30)));
 
 		final CrudService shareBigFileCrudService = new MongoDbCrudService(SHARE_BIG_FILE_COLLECTION);
-		final ShareBigFilesService shareBigFilesService = new ShareBigFilesServiceImpl(maxQuota);
 		final Storage storage = new StorageFactory(vertx, config, new ShareBigFileStorage()).getStorage();
+		final ShareBigFilesService shareBigFilesService = new ShareBigFilesServiceImpl(maxQuota, storage);
 		addController(new ShareBigFilesController(storage, shareBigFileCrudService, shareBigFilesService, log, maxQuota,
 				maxRepositoryQuota, expirationDateList));
 
@@ -75,7 +75,7 @@ public class ShareBigFiles extends BaseServer {
 
 		try {
 			new CronTrigger(vertx, purgeFilesCron).schedule(
-					new DeleteOldFile(timelineHelper, storage)
+					new DeleteOldFile(timelineHelper, storage, shareBigFilesService, config)
 			);
 		} catch (ParseException e) {
 			log.fatal("[Share Big File] Invalid cron expression.", e);

--- a/src/main/java/fr/openent/sharebigfiles/cron/DeleteOldFile.java
+++ b/src/main/java/fr/openent/sharebigfiles/cron/DeleteOldFile.java
@@ -20,6 +20,7 @@
 package fr.openent.sharebigfiles.cron;
 
 import fr.openent.sharebigfiles.ShareBigFiles;
+import fr.openent.sharebigfiles.services.ShareBigFilesService;
 import fr.openent.sharebigfiles.utils.DateUtils;
 import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.mongodb.MongoUpdateBuilder;
@@ -43,115 +44,161 @@ public class DeleteOldFile implements Handler<Long> {
 
     private final MongoDb mongo = MongoDb.getInstance();
     private final Storage storage;
+    private final boolean enableCheck;
+    private final boolean enableClean;
     private final TimelineHelper timelineHelper;
     private static final I18n i18n = I18n.getInstance();
+    private final ShareBigFilesService shareBigFilesService;
     private static final Logger log = LoggerFactory.getLogger(DeleteOldFile.class);
 
-    public DeleteOldFile(final TimelineHelper timelineHelper, final Storage storage) {
+    public DeleteOldFile(final TimelineHelper timelineHelper, final Storage storage, final ShareBigFilesService shareBigFilesService, final JsonObject config) {
         this.storage = storage;
         this.timelineHelper = timelineHelper;
+        this.shareBigFilesService = shareBigFilesService;
+        this.enableCheck = config.getBoolean("enableCheckFileCron", true);
+        this.enableClean = config.getBoolean("enableCleanFileCron", false);
     }
 
     @Override
     public void handle(Long event) {
+        this.removeExpiredFiles();
+        if (this.enableCheck) {
+            log.info("[cron][purge] starting check of outdated...");
+            this.shareBigFilesService.cleanOutdated(true).onComplete(e -> {
+                if (this.enableClean) {
+                    log.info("[cron][purge] starting clean of outdated...");
+                    this.shareBigFilesService.cleanOutdated(false);
+                } else {
+                    log.info("[cron][purge] clean of outdated is disabled...");
+                }
+            });
+        } else {
+            log.info("[cron][purge] check of outdated is disabled...");
+        }
+    }
+
+    private void removeExpiredFiles() {
+        log.info("[cron][purge] starting...");
         // Check the expiry date of file (Mongo) and removal if necessary (only swift file)
-        final JsonArray cond = new JsonArray().add(new JsonObject().put("expiryDate", new JsonObject()
-                .put("$lt", MongoDb.now()))).add(new JsonObject().put("outdated", new JsonObject()
-                .put("$exists", false)));
+        // fetch files that has expired AND outdated is not true
+        final JsonArray cond = new JsonArray()
+                .add(new JsonObject().put("expiryDate", new JsonObject().put("$lt", MongoDb.now())))
+                .add(new JsonObject().put("outdated", new JsonObject().put("$ne", true)));
         final JsonObject query = new JsonObject().put("$and", cond);
-        mongo.find(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, query, new Handler<Message<JsonObject>>() {
-            @Override
-            public void handle(Message<JsonObject> event) {
-                final JsonArray res = event.body().getJsonArray("results");
+        mongo.find(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, query, findResult -> {
+            final JsonArray res = findResult.body().getJsonArray("results");
 
-                if ("ok".equals(event.body().getString("status")) && res != null && res.size() > 0) {
-                    final JsonArray ids = new JsonArray();
-
+            if ("ok".equals(findResult.body().getString("status")) && res != null) {
+                if (res.size() > 0) {
+                    final List<String> ids = new ArrayList<>();
+                    // iterate over results and send notification
                     for (Object object : res) {
                         if (!(object instanceof JsonObject)) continue;
+                        // extract fileId
                         final JsonObject elem = (JsonObject) object;
                         ids.add(elem.getString("fileId"));
-
-                        final String fileName = elem.getString("fileNameLabel");
-                        final String createdDate = DateUtils.format(MongoDb.parseIsoDate(elem.getJsonObject("created")));
-                        final String expiryFileDate = DateUtils.format(MongoDb.parseIsoDate(elem.getJsonObject("expiryDate")));
-                        final String locale = elem.getString("locale", "fr");
-
-                        final List<String> recipients = new ArrayList<String>();
-                        recipients.add(elem.getJsonObject("owner").getString("userId"));
-                        final JsonObject params = new JsonObject()
-                                .put("resourceName", fileName)
-                                .put("body", i18n.translate("sharebigfiles.cron.notify.body",
-                                        I18n.DEFAULT_DOMAIN, locale, createdDate, expiryFileDate));
-
-                        timelineHelper.notifyTimeline(new JsonHttpServerRequest(new JsonObject()
-                                        .put("headers", new JsonObject().put("Accept-Language", locale))),
-                                "sharebigfiles.delete", null, recipients, null, params);
+                        // send notification
+                        this.sendNotification(elem);
                     }
-                    storage.removeFiles(ids, new Handler<JsonObject>() {
-                        @Override
-                        public void handle(JsonObject event) {
-                            if ("ok".equals(event.getString("status"))) {
-                                final MongoUpdateBuilder modifier = new MongoUpdateBuilder();
-                                //one adding out-of-date flag
-                                modifier.set("outdated", true);
-                                //two deleting share
-                                modifier.unset("shared");
-                                mongo.update(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, query, modifier.build(), false, true, null, new Handler<Message<JsonObject>>() {
-                                    @Override
-                                    public void handle(Message<JsonObject> event) {
-                                        if (!"ok".equals(event.body().getString("status"))) {
-                                            log.error(event.body().getString("message"));
-                                        }
-                                    }
-                                });
-                            } else {
-                                final JsonArray errors = event.getJsonArray("errors");
-                                Set<String> filesNotFound = new HashSet<String>();
-                                Set<String> globalErrors = new HashSet<String>();
-                                for (int i = 0; i < errors.size(); i++) {
-                                    final JsonObject jo = errors.getJsonObject(i);
-                                    final String errorMessage = jo.getString("message");
-                                    final String fileId = jo.getString("id");
-                                    log.error("Can't delete swift file id : " + fileId + ", error : " + errorMessage);
-                                    final CharSequence FILE_NOT_FOUND_ERROR_MESSAGE = "NoSuchFileException";
-                                    if (errorMessage.contains(FILE_NOT_FOUND_ERROR_MESSAGE)) {
-                                        filesNotFound.add(fileId);
-                                    }
-                                    globalErrors.add(fileId);
-                                }
-
-                                Set<String> filesToUpdate = new HashSet<String>();
-                                filesToUpdate.addAll(filesNotFound);
-
-                                final List idList = ids.getList();
-                                for (Object identifier : idList) {
-                                    final String id = (String) identifier;
-                                    if (!globalErrors.contains(id)) {
-                                        filesToUpdate.add(id);
-                                    }
-                                }
-
-                                JsonArray idsToUpdate = new JsonArray(new ArrayList<>(filesToUpdate));
-                                final JsonObject queryInIdFile = new JsonObject().put("fileId", new JsonObject().put("$in", idsToUpdate));
-
-                                final MongoUpdateBuilder modifier = new MongoUpdateBuilder();
-                                modifier.set("outdated", true);
-                                modifier.unset("shared");
-                                mongo.update(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, queryInIdFile, modifier.build(), false, true, null, new Handler<Message<JsonObject>>() {
-                                    @Override
-                                    public void handle(Message<JsonObject> event) {
-                                        if (!"ok".equals(event.body().getString("status"))) {
-                                            log.error(event.body().getString("message"));
-                                        }
-                                    }
-                                });
-
-
-                            }
-                        }
-                    });
+                    // remove files
+                    this.removeFiles(ids);
+                } else {
+                    log.info("[cron][purge] finished. Nothing to delete");
                 }
+            }
+        });
+    }
+
+    private void sendNotification(final JsonObject elem) {
+        // extract filename, dates... from data
+        final String fileName = elem.getString("fileNameLabel");
+        final String createdDate = DateUtils.format(MongoDb.parseIsoDate(elem.getJsonObject("created")));
+        final String expiryFileDate = DateUtils.format(MongoDb.parseIsoDate(elem.getJsonObject("expiryDate")));
+        final String locale = elem.getString("locale", "fr");
+        // the owner receive the notification
+        final List<String> recipients = new ArrayList<String>();
+        recipients.add(elem.getJsonObject("owner").getString("userId"));
+        // set notification params
+        final JsonObject params = new JsonObject()
+                .put("resourceName", fileName)
+                .put("body", i18n.translate("sharebigfiles.cron.notify.body",
+                        I18n.DEFAULT_DOMAIN, locale, createdDate, expiryFileDate));
+        // send notification
+        timelineHelper.notifyTimeline(new JsonHttpServerRequest(new JsonObject()
+                        .put("headers", new JsonObject().put("Accept-Language", locale))),
+                "sharebigfiles.delete", null, recipients, null, params);
+    }
+
+    private void removeFiles(final List<String> ids) {
+        // remove files from disk
+        log.info("[cron][purge] Deleting... numberOfFiles=" + ids.size());
+        storage.removeFiles(new JsonArray(ids), removeFileRes -> {
+            if ("ok".equals(removeFileRes.getString("status"))) {
+                log.info("[cron][purge] Deleted successfully. numberOfFiles=" + ids.size());
+                this.onDeleteSuccess(ids);
+            } else {
+                log.warn("[cron][purge] Delete failed. numberOfFiles=" + ids.size());
+                this.onDeleteFailed(ids, removeFileRes.getJsonArray("errors", new JsonArray()));
+            }
+        });
+    }
+
+    private void onDeleteSuccess(final List<String> ids) {
+        log.info("[cron][purge] Updating status after removeDisk succeed. numberOfFiles=" + ids.size());
+        // SET outdated true AND remove shared
+        final MongoUpdateBuilder modifier = new MongoUpdateBuilder();
+        modifier.set("outdated", true);
+        modifier.unset("shared");
+        // update all files WHERE fileIds=ids
+        final JsonArray idsToUpdate = new JsonArray(ids);
+        final JsonObject queryInIdFile = new JsonObject().put("fileId", new JsonObject().put("$in", idsToUpdate));
+        mongo.update(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, queryInIdFile, modifier.build(), false, true, null, event -> {
+            if ("ok".equals(event.body().getString("status"))) {
+                log.info("[cron][purge] Finished successfully. deletedFail=0 deletedSuccess=" + ids.size());
+            } else {
+                log.error("[cron][purge] Finish with error. deletedFail=0 deletedSuccess=" + ids.size() + " error=" + event.body().getString("message"));
+
+            }
+        });
+    }
+
+    private void onDeleteFailed(final List<String> ids, final JsonArray errors) {
+        log.warn("[cron][purge] Updating status after removeDisk failed. numberOfFiles=" + ids.size());
+        // iterate over errors to detect file not found
+        final Set<String> filesNotFound = new HashSet<String>();
+        final Set<String> globalErrors = new HashSet<String>();
+        for (int i = 0; i < errors.size(); i++) {
+            final JsonObject jo = errors.getJsonObject(i);
+            final String errorMessage = jo.getString("message");
+            final String fileId = jo.getString("id");
+            log.error("[cron][purge] Can't delete file id : " + fileId + ", error : " + errorMessage);
+            final CharSequence FILE_NOT_FOUND_ERROR_MESSAGE = "NoSuchFileException";
+            if (errorMessage.contains(FILE_NOT_FOUND_ERROR_MESSAGE)) {
+                filesNotFound.add(fileId);
+            }
+            globalErrors.add(fileId);
+        }
+        // list of fileIds to update
+        final Set<String> deletedFileIds = new HashSet<String>();
+        deletedFileIds.addAll(filesNotFound);
+        for (String id : ids) {
+            if (!globalErrors.contains(id)) {
+                deletedFileIds.add(id);
+            }
+        }
+        // update files WHERE fileId in ids
+        final JsonArray idsToUpdate = new JsonArray(new ArrayList<>(deletedFileIds));
+        final JsonObject queryInIdFile = new JsonObject().put("fileId", new JsonObject().put("$in", idsToUpdate));
+        // SET outdated true AND remove shared
+        final MongoUpdateBuilder modifier = new MongoUpdateBuilder();
+        modifier.set("outdated", true);
+        modifier.unset("shared");
+        mongo.update(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, queryInIdFile, modifier.build(), false, true, null, event -> {
+            if ("ok".equals(event.body().getString("status"))) {
+                final int failed = ids.size() - deletedFileIds.size();
+                log.info("[cron][purge] Finished successfully. deletedSuccess=" + deletedFileIds.size() + " deletedFail=" + failed);
+            } else {
+                log.error("[cron][purge] Finish with error. deletedSuccess=0 deletedFail=" + ids.size() + " error=" + event.body().getString("message"));
             }
         });
     }

--- a/src/main/java/fr/openent/sharebigfiles/services/ShareBigFilesService.java
+++ b/src/main/java/fr/openent/sharebigfiles/services/ShareBigFilesService.java
@@ -19,7 +19,9 @@
 
 package fr.openent.sharebigfiles.services;
 
+import fr.openent.sharebigfiles.to.BigFile;
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import org.entcore.common.user.UserInfos;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
@@ -52,4 +54,7 @@ public interface ShareBigFilesService {
 	void deletes(final List<String> ids, final Handler<Either<String, JsonObject>> handler);
 
 	void deletesRemanent(final List<String> ids, final Handler<Either<String, JsonObject>> handler);
+
+	Future<List<BigFile>> cleanOutdated(boolean checkOnly);
+
 }

--- a/src/main/java/fr/openent/sharebigfiles/services/ShareBigFilesServiceImpl.java
+++ b/src/main/java/fr/openent/sharebigfiles/services/ShareBigFilesServiceImpl.java
@@ -21,11 +21,16 @@ package fr.openent.sharebigfiles.services;
 
 import com.mongodb.QueryBuilder;
 import fr.openent.sharebigfiles.ShareBigFiles;
+import fr.openent.sharebigfiles.to.BigFile;
 import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.mongodb.MongoQueryBuilder;
 import fr.wseduc.mongodb.MongoUpdateBuilder;
 import fr.wseduc.webutils.Either;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import org.entcore.common.service.VisibilityFilter;
+import org.entcore.common.storage.Storage;
 import org.entcore.common.user.UserInfos;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
@@ -34,8 +39,10 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.entcore.common.mongodb.MongoDbResult.validActionResultHandler;
 import static org.entcore.common.mongodb.MongoDbResult.validResultsHandler;
@@ -46,82 +53,224 @@ import static org.entcore.common.mongodb.MongoDbResult.validResultsHandler;
  */
 public class ShareBigFilesServiceImpl implements ShareBigFilesService {
 
-	private static final Logger log = LoggerFactory.getLogger(ShareBigFilesServiceImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(ShareBigFilesServiceImpl.class);
 
-	private final MongoDb mongo = MongoDb.getInstance();
+    private final MongoDb mongo = MongoDb.getInstance();
 
-	private final Long maxQuota;
+    private final Long maxQuota;
+    private final Storage storage;
 
-	public ShareBigFilesServiceImpl(final Long maxQuota) {
-		this.maxQuota = maxQuota;
-	}
+    public ShareBigFilesServiceImpl(final Long maxQuota, final Storage storage) {
+        this.storage = storage;
+        this.maxQuota = maxQuota;
+    }
 
-	@Override
-	public void updateDownloadLogs(final String id, final UserInfos user, final Handler<JsonObject> handler) {
-		final QueryBuilder query = QueryBuilder.start("_id").is(id);
+    @Override
+    public void updateDownloadLogs(final String id, final UserInfos user, final Handler<JsonObject> handler) {
+        final QueryBuilder query = QueryBuilder.start("_id").is(id);
 
-		final JsonObject logElem = new JsonObject().put("userDisplayName", user.getUsername()).put("downloadDate", MongoDb.now());
-		final MongoUpdateBuilder modifier = new MongoUpdateBuilder();
-		modifier.addToSet("downloadLogs", logElem);
-		mongo.update(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(query),
-				modifier.build(), new Handler<Message<JsonObject>>() {
-					@Override
-					public void handle(Message<JsonObject> event) {
-						if ("ok".equals(event.body().getString("status"))) {
-							handler.handle(new JsonObject().put("status", "ok"));
-						} else {
-							handler.handle(new JsonObject().put("status", "error")
-									.put("message", event.body().getString("message")));
-						}
-					}
-				});
-	}
+        final JsonObject logElem = new JsonObject().put("userDisplayName", user.getUsername()).put("downloadDate", MongoDb.now());
+        final MongoUpdateBuilder modifier = new MongoUpdateBuilder();
+        modifier.addToSet("downloadLogs", logElem);
+        mongo.update(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(query),
+                modifier.build(), new Handler<Message<JsonObject>>() {
+                    @Override
+                    public void handle(Message<JsonObject> event) {
+                        if ("ok".equals(event.body().getString("status"))) {
+                            handler.handle(new JsonObject().put("status", "ok"));
+                        } else {
+                            handler.handle(new JsonObject().put("status", "error")
+                                    .put("message", event.body().getString("message")));
+                        }
+                    }
+                });
+    }
 
-	@Override
-	public void getQuotaData(final String userId, final Handler<JsonObject> handler) {
-		final QueryBuilder query = QueryBuilder.start("owner.userId").is(userId).put("fileMetadata.size").exists(true);
+    @Override
+    public void getQuotaData(final String userId, final Handler<JsonObject> handler) {
+        final QueryBuilder query = QueryBuilder.start("owner.userId").is(userId).put("fileMetadata.size").exists(true);
 
-		mongo.find(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(query), new Handler<Message<JsonObject>>() {
-			@Override
-			public void handle(Message<JsonObject> event) {
-				final JsonArray res = event.body().getJsonArray("results");
-				final String status = event.body().getString("status");
-				final JsonObject j = new JsonObject();
+        mongo.find(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(query), new Handler<Message<JsonObject>>() {
+            @Override
+            public void handle(Message<JsonObject> event) {
+                final JsonArray res = event.body().getJsonArray("results");
+                final String status = event.body().getString("status");
+                final JsonObject j = new JsonObject();
 
-				if ("ok".equals(status) && res != null) {
-					Long totalUser = 0L;
-					for (Object object : res) {
-						if (!(object instanceof JsonObject)) continue;
-						totalUser += ((JsonObject) object).getJsonObject("fileMetadata").getLong("size");
-					}
-					final Long residualUser = ShareBigFilesServiceImpl.this.maxQuota - totalUser;
-					final Long residualUserSize = (residualUser < 0) ? 0L : residualUser;
+                if ("ok".equals(status) && res != null) {
+                    Long totalUser = 0L;
+                    for (Object object : res) {
+                        if (!(object instanceof JsonObject)) continue;
+                        totalUser += ((JsonObject) object).getJsonObject("fileMetadata").getLong("size");
+                    }
+                    final Long residualUser = ShareBigFilesServiceImpl.this.maxQuota - totalUser;
+                    final Long residualUserSize = (residualUser < 0) ? 0L : residualUser;
 
-					handler.handle(j.put("residualQuota", residualUserSize).put("status", "ok"));
-				} else {
-					handler.handle(j.put("status", status));
-				}
-			}
-		});
-	}
+                    handler.handle(j.put("residualQuota", residualUserSize).put("status", "ok"));
+                } else {
+                    handler.handle(j.put("status", status));
+                }
+            }
+        });
+    }
 
-	public void retrieves(List<String> ids, final JsonObject projection, UserInfos user, Handler<Either<String, JsonArray>> handler) {
-		QueryBuilder builder = QueryBuilder.start("_id").in(new HashSet<String>(ids));
-		if (user == null) {
-			builder.put("visibility").is(VisibilityFilter.PUBLIC.name());
-		}
-		mongo.find(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(builder),
-				null, projection, validResultsHandler(handler));
-	}
+    public void retrieves(List<String> ids, final JsonObject projection, UserInfos user, Handler<Either<String, JsonArray>> handler) {
+        QueryBuilder builder = QueryBuilder.start("_id").in(new HashSet<String>(ids));
+        if (user == null) {
+            builder.put("visibility").is(VisibilityFilter.PUBLIC.name());
+        }
+        mongo.find(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(builder),
+                null, projection, validResultsHandler(handler));
+    }
 
-	public void deletes(List<String> ids, Handler<Either<String, JsonObject>> handler) {
-		QueryBuilder q = QueryBuilder.start("_id").in(new HashSet<String>(ids));
-		mongo.delete(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(q), validActionResultHandler(handler));
-	}
+    public void deletes(List<String> ids, Handler<Either<String, JsonObject>> handler) {
+        QueryBuilder q = QueryBuilder.start("_id").in(new HashSet<String>(ids));
+        mongo.delete(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(q), validActionResultHandler(handler));
+    }
 
-	public void deletesRemanent(List<String> ids, Handler<Either<String, JsonObject>> handler) {
-		QueryBuilder q = QueryBuilder.start("fileId").in(new HashSet<String>(ids));
-		mongo.delete(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(q), validActionResultHandler(handler));
-	}
+    public void deletesRemanent(List<String> ids, Handler<Either<String, JsonObject>> handler) {
+        QueryBuilder q = QueryBuilder.start("fileId").in(new HashSet<String>(ids));
+        mongo.delete(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, MongoQueryBuilder.build(q), validActionResultHandler(handler));
+    }
 
+    @Override
+    public Future<List<BigFile>> cleanOutdated(boolean checkOnly) {
+        if (checkOnly) {
+            log.info("[clean][check] starting...");
+            return this.findOutdatedFile(FindFilter.NotDeleted).compose(outdated -> {
+                log.info("[clean][check] before check. numberOfFilesToCheck="+outdated.size());
+                return this.checkFileExistence(outdated);
+            }).compose(checked -> {
+                final List<BigFile> toDelete = checked.stream().filter(t -> t.getStatus().equals(BigFile.Status.ToDelete)).collect(Collectors.toList());
+                final List<BigFile> deleted = checked.stream().filter(t -> t.getStatus().equals(BigFile.Status.Deleted)).collect(Collectors.toList());
+                log.info(String.format("[clean][check] after check. numberOfFilesToDelete=%s numberOfFileDeleted=%s",toDelete.size(), deleted.size()));
+                return CompositeFuture.all(this.saveFileStatus(toDelete,BigFile.Status.ToDelete), this.saveFileStatus(deleted, BigFile.Status.Deleted)).map(e -> {
+                    log.info(String.format("[clean][check] finished. numberOfFilesToDelete=%s numberOfFileDeleted=%s",toDelete.size(), deleted.size()));
+                    return checked;
+                });
+            });
+        } else {
+            log.info("[clean][force] starting...");
+            return this.findOutdatedFile(FindFilter.ToDelete).compose(outdated -> {
+                log.info("[clean][force] numberOfFilesToDelete="+outdated.size());
+                return this.deleteFileFromDisk(outdated);
+            }).compose(afterDelete -> {
+                final List<BigFile> toDelete = afterDelete.stream().filter(t -> t.getStatus().equals(BigFile.Status.ToDelete)).collect(Collectors.toList());
+                final List<BigFile> deleted = afterDelete.stream().filter(t -> t.getStatus().equals(BigFile.Status.Deleted)).collect(Collectors.toList());
+                log.info(String.format("[clean][force] after delete. numberOfFilesToDelete=%s numberOfFileDeleted=%s",toDelete.size(), deleted.size()));
+                return this.saveFileStatus(deleted, BigFile.Status.Deleted).map(e -> {
+                    log.info(String.format("[clean][force] finished. numberOfFilesToDelete=%s numberOfFileDeleted=%s",toDelete.size(), deleted.size()));
+                    return afterDelete;
+                });
+            });
+        }
+    }
+
+    private Future<List<BigFile>> findOutdatedFile(final FindFilter filter) {
+        final Promise<List<BigFile>> promise = Promise.promise();
+        // fetch files that has expired AND outdated is true AND checkOnDisk is not Deleted
+        final JsonArray cond = new JsonArray()
+                .add(new JsonObject().put("expiryDate", new JsonObject().put("$lt", MongoDb.now())))
+                .add(new JsonObject().put("outdated", new JsonObject().put("$eq", true)));
+        switch (filter) {
+            case ToDelete: {
+                cond.add(new JsonObject().put("checkOnDisk", new JsonObject().put("$eq", BigFile.Status.ToDelete.name())));
+                break;
+            }
+            case NotDeleted: {
+                cond.add(new JsonObject().put("checkOnDisk", new JsonObject().put("$ne", BigFile.Status.Deleted.name())));
+                break;
+            }
+        }
+        ;
+        final JsonObject query = new JsonObject().put("$and", cond);
+        mongo.find(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, query, findResult -> {
+            if ("ok".equals(findResult.body().getString("status")) && findResult != null) {
+                final List<BigFile> files = new ArrayList<>();
+                final JsonArray res = findResult.body().getJsonArray("results");
+                if (res.size() > 0) {
+                    // get ids from result
+                    for (Object object : res) {
+                        if (!(object instanceof JsonObject)) continue;
+                        // extract fileId
+                        final JsonObject elem = (JsonObject) object;
+                        files.add(BigFile.fromJSON(elem));
+                    }
+                    promise.complete(files);
+                } else {
+                    // no result
+                    promise.complete(files);
+                }
+            } else {
+                promise.fail(findResult.body().getString("message", "find failed"));
+            }
+        });
+        return promise.future();
+    }
+
+    private Future<List<BigFile>> checkFileExistence(final List<BigFile> files) {
+        final List<Future> futures = new ArrayList<>();
+        for (final BigFile file : files) {
+            final Promise<BigFile> promise = Promise.promise();
+            futures.add(promise.future());
+            this.storage.fileStats(file.getFileId(), (res) -> {
+                if (res.succeeded()) {
+                    promise.complete(new BigFile(file, BigFile.Status.ToDelete));
+                } else {
+                    promise.complete(new BigFile(file, BigFile.Status.Deleted));
+                }
+            });
+        }
+        return CompositeFuture.all(futures).map(e -> e.list());
+    }
+
+    private Future<List<BigFile>> deleteFileFromDisk(final List<BigFile> files) {
+        final List<Future> futures = new ArrayList<>();
+        for (final BigFile file : files) {
+            final Promise<BigFile> promise = Promise.promise();
+            futures.add(promise.future());
+            this.storage.removeFile(file.getFileId(), (resDelete) -> {
+                if ("ok".equals(resDelete.getString("status"))) {
+                    promise.complete(new BigFile(file, BigFile.Status.Deleted));
+                } else {
+                    // check if file exists
+                    this.storage.fileStats(file.getFileId(), (resStats) -> {
+                        if (resStats.succeeded()) {
+                            promise.complete(new BigFile(file, BigFile.Status.ToDelete));
+                            log.error(String.format("[clean][force] could not delete file. id=%s fileId=%s",file.getId(), file.getId()), resDelete.getString("message"));
+                        } else {
+                            promise.complete(new BigFile(file, BigFile.Status.Deleted));
+                        }
+                    });
+                }
+            });
+        }
+        return CompositeFuture.all(futures).map(e -> e.list());
+    }
+
+    private Future<List<BigFile>> saveFileStatus(final List<BigFile> files, final BigFile.Status status) {
+        if(files.isEmpty()){
+            return Future.succeededFuture(new ArrayList<>());
+        }
+        final Promise<List<BigFile>> promise = Promise.promise();
+        final List<String> ids = files.stream().map(file -> file.getId()).collect(Collectors.toList());
+        // SET outdated true AND remove shared AND deleteCheck true
+        final MongoUpdateBuilder modifier = new MongoUpdateBuilder();
+        modifier.set("checkOnDisk", status.name());
+        // update all files WHERE fileIds=ids
+        final JsonArray idsToUpdate = new JsonArray(ids);
+        final JsonObject queryInIdFile = new JsonObject().put("_id", new JsonObject().put("$in", idsToUpdate));
+        mongo.update(ShareBigFiles.SHARE_BIG_FILE_COLLECTION, queryInIdFile, modifier.build(), false, true, null, event -> {
+            if ("ok".equals(event.body().getString("status"))) {
+                promise.complete(files);
+            } else {
+                promise.fail(event.body().getString("message"));
+            }
+        });
+        return promise.future();
+    }
+
+    enum FindFilter {
+        NotDeleted, ToDelete
+    }
 }

--- a/src/main/java/fr/openent/sharebigfiles/to/BigFile.java
+++ b/src/main/java/fr/openent/sharebigfiles/to/BigFile.java
@@ -1,0 +1,70 @@
+package fr.openent.sharebigfiles.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Arrays;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BigFile {
+
+    public enum Status {
+        Deleted, ToKeep, ToDelete
+    }
+
+    private final String id;
+    private final String fileId;
+    private final Status status;
+    private final boolean outdated;
+
+    @JsonCreator
+    public BigFile(@JsonProperty("_id") String id, @JsonProperty("fileId") String fileId, @JsonProperty("checkOnDisk") String status, @JsonProperty("outdated") boolean outdated) {
+        this.id = id;
+        this.fileId = fileId;
+        this.outdated = outdated;
+        this.status = Arrays.stream(Status.values()).filter(a -> a.name().equals(status)).findFirst().orElse(Status.ToKeep);
+    }
+
+    public BigFile(final BigFile file, final Status status) {
+        this.id = file.id;
+        this.fileId = file.fileId;
+        this.status = status;
+        this.outdated = file.outdated;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getFileId() {
+        return fileId;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public boolean isOutdated() {
+        return outdated;
+    }
+
+    @Override
+    public String toString() {
+        return "PurgeResult{" +
+                "id='" + id + '\'' +
+                ", fileId='" + fileId + '\'' +
+                ", status=" + status +
+                ", outdated=" + outdated +
+                '}';
+    }
+
+    public JsonObject toJSON(){
+        return JsonObject.mapFrom(this);
+    }
+
+    public static BigFile fromJSON(final JsonObject json){
+        return json.mapTo(BigFile.class);
+    }
+}


### PR DESCRIPTION
# Description

Pour des raisons inconnus, certains fichiers expirés n'étaient pas supprimés du disk.
Cette PR vient:
- ajouter des logs sur la cron de purge
- améliorer les requêtes mongo de la cron de purge
- ajouter une tâche dans la cron qui vient vérifier que les fichiers expirés sont bien supprimés sur disk
- ajouter une tâche dans la cron qui vient supprimer les fichiers expirés et toujours présent sur disk

Deux nouvelles config sont crées:
- enableCheckFileCron (par défaut true) qui vérifie que les fichiers sur disk ont bien été supprimés
- enableCleanFileCron (par défaut false) qui supprime que les fichiers expirés qui sont tjrs sur disk

